### PR TITLE
Bring rustecs up to date with c4a3be6b & 221edbae

### DIFF
--- a/rustecs_macros/src/generate/intermediate.rs
+++ b/rustecs_macros/src/generate/intermediate.rs
@@ -37,7 +37,7 @@ pub struct Component {
 impl Component {
 	pub fn generate(context: &ExtCtxt, path: &ast::Path) -> Component {
 		let ident = path.segments.last().unwrap().identifier;
-		let ty = context.ty_path(path.clone(), None);
+		let ty = context.ty_path(path.clone());
 
 		let var_name = ast::Ident::new(
 			token::intern(camel_to_snake_case(ident).as_slice())

--- a/rustecs_macros/src/parse.rs
+++ b/rustecs_macros/src/parse.rs
@@ -36,7 +36,7 @@ impl World {
 			match declaration.as_str() {
 				"components" => {
 					loop {
-						components.push(parser.parse_path(PathParsingMode::LifetimeAndTypesWithoutColons).path);
+						components.push(parser.parse_path(PathParsingMode::LifetimeAndTypesWithoutColons));
 
 						parser.eat(&token::Comma);
 						if parser.eat(&token::Semi) {


### PR DESCRIPTION
rust-lang/rust@c4a3be6b and rust-lang/rust@221edbae changed AstBuilder
and Parser, bring the source up to date with this.

Fixes #8.
